### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+build
+npm-debug.log
+.env
+.DS_Store


### PR DESCRIPTION
Adds a git ignore file to ignore node module files which should not be included in the source control. This file also includes common files/folders that should also not be added.